### PR TITLE
pre-commit hooks should not set verbose: true

### DIFF
--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -9,4 +9,3 @@
     entry: bashate
     language: python
     types: [shell]
-    verbose: true


### PR DESCRIPTION
this is a debugging flag, I'm temporarily removing this from pre-commit.com for now, please fix this and revert this change:  https://github.com/pre-commit/pre-commit.com/commit/db95323e9be54159ce8e0d602728aa8510d248fd