### PR TITLE
Do not explicitly set verbose for pre-commit

### DIFF
--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -1,7 +1,7 @@
 ---
 
 # For use with pre-commit.
-# See usage instructions at http://pre-commit.com
+# See usage instructions at https://pre-commit.com
 
 -   id: bashate
     name: bashate
@@ -9,4 +9,3 @@
     entry: bashate
     language: python
     types: [shell]
-    verbose: true


### PR DESCRIPTION
The user normally decides if `pre-commit` hook should be verbose or not.
Right now, the project I maintain is using more than 20 hooks and this is the only one, which sets `verbose: true` by default.
Normally, users will turn on verbose when they want to.